### PR TITLE
apbs: make shebang portable

### DIFF
--- a/scripts/apbs
+++ b/scripts/apbs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Android Portable Build Script (apbs)
 # Isaac Pateau (Zaclimon)


### PR DESCRIPTION
It will have problems at least with NixOS, cause it doesn't have `/bin/bash`